### PR TITLE
Experimental - Fix Provisioning and removed "Banning"

### DIFF
--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -5,7 +5,7 @@ require 'pony'
 class SiriProxy::Connection < EventMachine::Connection
   include EventMachine::Protocols::LineText2
   
-  attr_accessor :other_connection, :name, :ssled, :output_buffer, :input_buffer, :processed_headers, :unzip_stream, :zip_stream, :consumed_ace, :unzipped_input, :unzipped_output, :last_ref_id, :plugin_manager,:is_4S, :sessionValidationData, :speechId, :assistantId, :aceId, :speechId_avail, :assistantId_avail, :validationData_avail, :key,
+  attr_accessor :other_connection, :name, :ssled, :output_buffer, :input_buffer, :processed_headers, :unzip_stream, :zip_stream, :consumed_ace, :unzipped_input, :unzipped_output, :last_ref_id, :plugin_manager,:is_4S, :sessionValidationData, :speechId, :assistantId, :aceId, :speechId_avail, :assistantId_avail, :validationData_avail, :key
   def last_ref_id=(ref_id)
     @last_ref_id = ref_id
     self.other_connection.last_ref_id = ref_id if other_connection.last_ref_id != ref_id

--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -494,7 +494,7 @@ class SiriProxy::Connection < EventMachine::Connection
             puts "[Warning - SiriProxy] This is not usual maybe a device got banned"
             self.assistantId_avail=false
           else
-            puts "[Info - SiriProxy] using/created speechID: #{object["properties"]["assistantId"]}"
+            puts "[Info - SiriProxy] using/created assistantId: #{object["properties"]["assistantId"]}"
              self.assistantId_avail=true
           end
 				end

--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -5,7 +5,7 @@ require 'pony'
 class SiriProxy::Connection < EventMachine::Connection
   include EventMachine::Protocols::LineText2
   
-  attr_accessor :other_connection, :name, :ssled, :output_buffer, :input_buffer, :processed_headers, :unzip_stream, :zip_stream, :consumed_ace, :unzipped_input, :unzipped_output, :last_ref_id, :plugin_manager,:is_4S, :sessionValidationData, :speechId, :assistantId, :aceId, :speechId_avail, :assistantId_avail, :validationData_avail, :key, :is_GetSessionCertificate
+  attr_accessor :other_connection, :name, :ssled, :output_buffer, :input_buffer, :processed_headers, :unzip_stream, :zip_stream, :consumed_ace, :unzipped_input, :unzipped_output, :last_ref_id, :plugin_manager,:is_4S, :sessionValidationData, :speechId, :assistantId, :aceId, :speechId_avail, :assistantId_avail, :validationData_avail, :key,
   def last_ref_id=(ref_id)
     @last_ref_id = ref_id
     self.other_connection.last_ref_id = ref_id if other_connection.last_ref_id != ref_id
@@ -22,14 +22,19 @@ class SiriProxy::Connection < EventMachine::Connection
     self.zip_stream = Zlib::Deflate.new
     self.consumed_ace = false	
     self.is_4S = false 			#bool if its iPhone 4S
-    self.is_GetSessionCertificate = false #bool if phone is setup
     self.sessionValidationData = nil	#validationData
     self.speechId = nil			#speechID
     self.assistantId = nil			#assistantID
     self.speechId_avail = false		#speechID available
     self.assistantId_avail = false		#assistantId available
-    self.validationData_avail = false	#validationData available		
     puts "[Info - SiriProxy] Created a connection!" 		
+    ##Checks For avalible keys before any object is loaded
+    available_keys=$keyDao.listkeys().count
+    if available_keys > 0
+      self.validationData_avail = true      
+      else 
+      self.validationData_avail = false
+    end     
   end
   
   #Changes
@@ -401,10 +406,6 @@ class SiriProxy::Connection < EventMachine::Connection
     end
     #Injected 
 
-    if object["class"]=="GetSessionCertificate"
-      puts "[Warning - SiriProxy] Seems phone is not setup yet..."
-      self.is_GetSessionCertificate = true
-    end
     if object["class"]=="SessionValidationFailed"
       puts "expired"
       get_validationData	      
@@ -511,7 +512,7 @@ class SiriProxy::Connection < EventMachine::Connection
     #keeping this for filters
     new_obj = received_object(object)
     #puts self.name
-    if self.validationData_avail==false and self.name=='iPhone' and self.is_4S==false and self.is_GetSessionCertificate = false
+    if self.validationData_avail==false and self.name=='iPhone' and self.is_4S==false 
       puts "[Protection - Siriproxy] Dropping Object from #{self.name}] #{object["class"]} due to no validation available" if $LOG_LEVEL >= 1      
       if object["class"]=="FinishSpeech" 
         
@@ -520,14 +521,15 @@ class SiriProxy::Connection < EventMachine::Connection
       return nil
     end
     
-    if self.validationData_avail==true and self.name=='iPhone' and self.is_4S==false and (self.speechId_avail==false or self.assistantId_avail==false) and self.is_GetSessionCertificate = false
-      puts "[Protection - Siriproxy] Dropping Object from #{self.name}] #{object["class"]} due to Backlisted Device!" if $LOG_LEVEL >= 1      
-      if object["class"]=="FinishSpeech" 
-        
-      end
-      pp object if $LOG_LEVEL > 3
-      return nil
-    end
+    ## --If the speechId and assistantId are nil, the phone is not setup, not banned..
+    #if self.validationData_avail==true and self.name=='iPhone' and self.is_4S==false and (self.speechId_avail==false or self.assistantId_avail==false)
+    #  puts "[Protection - Siriproxy] Dropping Object from #{self.name}] #{object["class"]} due to Backlisted Device!" if $LOG_LEVEL >= 1      
+    #  if object["class"]=="FinishSpeech" 
+    #    
+    #  end
+    #  pp object if $LOG_LEVEL > 3
+    #  return nil
+    #end
     
     
     if new_obj == nil 


### PR DESCRIPTION
If speechID and assistantId are blank, it is because the phone isn't setup, not because it is banned....

Now only lets phone provision of there is Valid key in the Database. Otherwise all oobjects are blocked of there are no keys in the database.
