### PR TITLE
Allow siriproxy's host to use the DNS server that redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ If you go for the above tutorial then there is no need to follow any instruction
 
 * __Not needed if you Jailbrake an iPhone 4S. Just install Spire on your 4S. Then you can point it to your server just like you do with any other iPhone 4.__
 
-Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (isiproxy uses Google's public DNS servers to resolve guzzoni.apple.com, so it may use your forwarding DNS server). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
+Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (siriproxy uses Google's public DNS servers to resolve guzzoni.apple.com, so it may use your forwarding DNS server). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
 Also if you dont have static ip you can use this dns python server. ([https://github.com/jimmykane/Roque-Dns-Server])
 
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ If you go for the above tutorial then there is no need to follow any instruction
 
 * __Not needed if you Jailbrake an iPhone 4S. Just install Spire on your 4S. Then you can point it to your server just like you do with any other iPhone 4.__
 
-Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (make sure that computer is not using your DNS server!). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
+Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (isiproxy uses Google's public DNS servers to resolve guzzoni.apple.com, so it may use your forwarding DNS server). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
 Also if you dont have static ip you can use this dns python server. ([https://github.com/jimmykane/Roque-Dns-Server])
 
 

--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -91,7 +91,7 @@ $keyDao.connect_to_db($my_db)
     EventMachine.run do
       begin
         puts "Starting SiriProxy on port #{$APP_CONFIG.port}.."
-        EventMachine::start_server('0.0.0.0', $APP_CONFIG.port, SiriProxy::Connection::Iphone ) { |conn|
+        EventMachine::start_server('0.0.0.0', $APP_CONFIG.port, SiriProxy::Connection::Iphone, $APP_CONFIG.upstream_dns) { |conn|
           $stderr.puts "start conn #{conn.inspect}" if $LOG_LEVEL > 3
           conn.plugin_manager = SiriProxy::PluginManager.new()
           conn.plugin_manager.iphone_conn = conn

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -262,6 +262,10 @@ class SiriProxy::CommandLine
     
   def parse_options
     $APP_CONFIG = OpenStruct.new(YAML.load_file(File.expand_path('~/.siriproxy/config.yml')))
+
+    # Google Public DNS servers
+    $APP_CONFIG.upstream_dns ||= %w[8.8.8.8 8.8.4.4]
+
     @branch = nil
     @option_parser = OptionParser.new do |opts|
       opts.on('-p', '--port PORT',     '[server]   port number for server (central or node)') do |port_num|
@@ -269,6 +273,9 @@ class SiriProxy::CommandLine
       end
       opts.on('-l', '--log LOG_LEVEL', '[server]   The level of debug information displayed (higher is more)') do |log_level|
         $APP_CONFIG.log_level = log_level
+      end
+      opts.on(      '--upstream-dns SERVERS', Array, '[server]   List of upstream DNS servers to query for the real guzzoni.apple.com.  Defaults to Google DNS servers') do |servers|
+        $APP_CONFIG.upstream_dns = servers
       end
       opts.on('-b', '--branch BRANCH', '[update]   Choose the branch to update from (default: master)') do |branch|
         @branch = branch

--- a/lib/siriproxy/connection/iphone.rb
+++ b/lib/siriproxy/connection/iphone.rb
@@ -1,12 +1,15 @@
+require 'resolv'
+
 #####
 # This is the connection to the iPhone
 #####
 class SiriProxy::Connection::Iphone < SiriProxy::Connection
-  def initialize
+  def initialize upstream_dns
     $conf.active_connections = EM.connection_count          
     puts "Create server for iPhone connection"
-    super
+    super()
     self.name = "iPhone"
+    @upstream_dns = upstream_dns
   end
 
   def post_init   #removed code from here to allow a 4s to connect!
@@ -16,10 +19,26 @@ class SiriProxy::Connection::Iphone < SiriProxy::Connection
       :verify_peer      => false)
   end
 
+  # Resolves guzzoni.apple.com using the Google DNS servers.  This allows the
+  # machine running siriproxy to use the DNS server returning fake records for
+  # guzzoni.apple.com.
+
+  def resolve_guzzoni
+    addresses = Resolv::DNS.open(nameserver: @upstream_dns) do |dns|
+      res = dns.getresources('guzzoni.apple.com', Resolv::DNS::Resource::IN::A)
+
+      res.map { |r| r.address }
+    end
+
+    addresses.map do |address|
+      address.address.unpack('C*').join('.')
+    end.sample
+  end
+
   def ssl_handshake_completed
     super
     begin
-      self.other_connection = EventMachine.connect('guzzoni.apple.com', 443, SiriProxy::Connection::Guzzoni)
+      self.other_connection = EventMachine.connect(resolve_guzzoni, 443, SiriProxy::Connection::Guzzoni)
       self.plugin_manager.guzzoni_conn = self.other_connection
       other_connection.other_connection = self #hehe
       other_connection.plugin_manager = plugin_manager


### PR DESCRIPTION
This pull request uses Ruby's Resolv library to request an A record for guzzoni.apple.com from Google's Public DNS servers.  Users can override the upstream DNS servers using `--upstream-dns`.
