### PR TITLE
Allow root privileges to be dropped after port 443 is bound

### DIFF
--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -188,6 +188,8 @@ $keyDao.connect_to_db($my_db)
           raise
         end
       end
+
+      EventMachine.set_effective_user($APP_CONFIG.user) if $APP_CONFIG.user
     end
   end
 end

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -270,6 +270,9 @@ class SiriProxy::CommandLine
       opts.on('-l', '--log LOG_LEVEL', '[server]   The level of debug information displayed (higher is more)') do |log_level|
         $APP_CONFIG.log_level = log_level
       end
+      opts.on('-u', '--user USER',     '[server]   The user to run as after launch') do |user|
+        $APP_CONFIG.user = user
+      end
       opts.on('-b', '--branch BRANCH', '[update]   Choose the branch to update from (default: master)') do |branch|
         @branch = branch
       end


### PR DESCRIPTION
There is no need for plugins or the rest of siriproxy to run as root past binding a port under 1025.  This patch adds the `--user` option and changes the effective process user after the port is bound.
