### PR TITLE
Add missing colon to 'spoken' symbol

### DIFF
--- a/lib/siriproxy/plugin_manager.rb
+++ b/lib/siriproxy/plugin_manager.rb
@@ -67,7 +67,7 @@ class SiriProxy::PluginManager < Cora
       self.apple_conn.block_rest_of_session if result
       return result
     rescue Exception=>e
-      respond e.to_s, spoken => "Oh no! A plugin crashed:"
+      respond e.to_s, :spoken => "Oh no! A plugin crashed:"
       log "Plugin Crashed: #{e}"
       return true
     end


### PR DESCRIPTION
Fix the syntax error in the error handler :)
