### PR TITLE
Added the possibility to block iPhone 5/4S/iPad3

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -53,6 +53,10 @@ server2: 'your.siri.proxy.server.com'
 # thus denying access
 private_server: 'OFF'
 
+#In case of private_server is set to 'ON': This automaticaly sets key-donating devices like iPhone 4S/5 as invalid and they
+#must be set to true in database, if private_to_all_devices is 'ON'. Default: 'OFF'
+private_to_all_devices: 'OFF'
+
 #To make a Public server - less public, where the client needs to be in database, make clients_must_be_in_database true.
 #Note: The client will have to delete their com.apple.assistant.plist before they use your server.
 clients_must_be_in_database: false


### PR DESCRIPTION
This changes allow a real private server. If the parameter "private_to_all_devices" in the config.yml is set to "ON", Siri-native devices have to be unlocked in the database just like iPhone 4/3GS. If this parameter is 'OFF' or something other than 'ON', there is no difference to the previous version of siriproxy.
Please also accept the changes to connection.rb
